### PR TITLE
Fix: Correct a bug when default rows per page specified

### DIFF
--- a/docs/RELEASE_HISTORY.md
+++ b/docs/RELEASE_HISTORY.md
@@ -1,6 +1,11 @@
 # Release History
 
-## 0.2.0 - ?? December 2020
+## 0.1.11 - 24 December 2020
+
+- Fix a bug that resulted in incorrect paging when -1 was specified as the 
+`rowsPerPage` in the format object passed to the `<Tabular>` component.
+## 0.1.10 - 23 December 2020
+
 - Allow users to dynamically change the number rows/page displayed at runtime
 - Allow `styles` to be used as an alias for `decorators` in the format object passed on the `<tabular>` component. Note that in a future release `decorators` will be removed to eliminate any confusion between it and Javascript decorators.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabular-svelte",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "A Svelte component to display tabular data",
   "repository": {
     "type": "git",

--- a/src/Tabular.svelte
+++ b/src/Tabular.svelte
@@ -10,13 +10,6 @@
 
   export let definition
 
-  let currentNoRowsPerPage 
-  if ($rowsPerPage === 0) {
-    currentNoRowsPerPage = definition.dataSource.rowsPerPage === -1 
-      ? data.length : definition.dataSource.rowsPerPage
-    rowsPerPage.reset(currentNoRowsPerPage)
-  }
-
   const retrieveDataPage = (rowsToScroll, rowsPerPage) => {
     return definition.dataSource.reader(rowsToScroll, rowsPerPage)
   }
@@ -54,9 +47,6 @@
     })
   }
 
-  let data = retrieveDataPage(0,$rowsPerPage)
-  let componentRows = formatComponents()
-
   const scrollBackward = () => {
     const newFirstRowToDisplay = $firstRowToDisplay - $rowsPerPage
     if (newFirstRowToDisplay >= 0) {
@@ -81,6 +71,18 @@
     data = retrieveDataPage(0,$rowsPerPage)
     componentRows = formatComponents()
   }
+
+  let currentNoRowsPerPage 
+  let data = retrieveDataPage(0,$rowsPerPage)
+
+  if ($rowsPerPage === 0) {
+    currentNoRowsPerPage = definition.dataSource.rowsPerPage === -1 
+      ? data.length : definition.dataSource.rowsPerPage
+    rowsPerPage.reset(currentNoRowsPerPage)
+  }
+  
+  data = retrieveDataPage(0,$rowsPerPage)
+  let componentRows = formatComponents()
 
 </script>
 


### PR DESCRIPTION
Corrent a bug causing paging to fail when `-1` is specified as the value for `rowsPerPage` in the format object.

This error cause page forward requests to display an empty page of data.

Resolves: N/a
See also: N/a